### PR TITLE
feat(ai): IA-2 caché de explicaciones y factoría de proveedor

### DIFF
--- a/app/services/ai/cache.py
+++ b/app/services/ai/cache.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from app.models.ai_explanation import AIExplanation
+from app.models.finding import NormalizedFinding
+from app.services.ai.provider import AIProvider
+
+ExplanationKey = tuple[str, str, str, int | None, str]
+
+
+def explanation_cache_key(
+    provider_name: str,
+    model: str,
+    finding: NormalizedFinding,
+) -> ExplanationKey:
+    """
+    Clave de caché por categoría/estándar/regla (no por fichero/línea), de modo que
+    hallazgos equivalentes comparten explicación y son reproducibles (ADR-003).
+    """
+    return (
+        provider_name,
+        model,
+        finding.mvp_category,
+        finding.cwe_id,
+        finding.source_rule_id,
+    )
+
+
+class ExplanationCache:
+    """Caché en memoria de explicaciones IA, válida durante un escaneo."""
+
+    def __init__(self) -> None:
+        self._store: dict[ExplanationKey, AIExplanation] = {}
+
+    def get(self, key: ExplanationKey) -> AIExplanation | None:
+        return self._store.get(key)
+
+    def set(self, key: ExplanationKey, explanation: AIExplanation) -> None:
+        self._store[key] = explanation
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+
+def explain_cached(
+    provider: AIProvider,
+    finding: NormalizedFinding,
+    cache: ExplanationCache,
+) -> AIExplanation | None:
+    """
+    Devuelve la explicación del hallazgo usando la caché. En un acierto marca
+    `cached=True`; en un fallo llama al proveedor y guarda el resultado. Si el
+    proveedor devuelve None (degradación), no cachea.
+    """
+    key = explanation_cache_key(provider.name, provider.model, finding)
+    hit = cache.get(key)
+    if hit is not None:
+        return replace(hit, cached=True)
+    explanation = provider.explain(finding)
+    if explanation is None:
+        return None
+    cache.set(key, explanation)
+    return explanation

--- a/app/services/ai/factory.py
+++ b/app/services/ai/factory.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+
+from app.config import Settings, get_settings
+from app.services.ai.provider import AIProvider
+from app.services.ai.stub_provider import StubProvider
+
+logger = logging.getLogger(__name__)
+
+
+def get_ai_provider(settings: Settings | None = None) -> AIProvider | None:
+    """
+    Resuelve el proveedor de IA según la configuración (ADR-003).
+
+    Devuelve None (capa desactivada / degradación) cuando:
+    - `TFG_AI_EXPLANATIONS_ENABLED` está desactivado, o
+    - el proveedor configurado aún no está implementado en esta fase.
+
+    El resto del sistema trata None como "sin explicación", sin romper el análisis.
+    """
+    s = settings or get_settings()
+    if not s.ai_explanations_enabled:
+        return None
+
+    if s.ai_provider == "stub":
+        return StubProvider()
+
+    # OllamaProvider (IA-5) y proveedor API opcional aún no implementados.
+    logger.warning(
+        "Proveedor de IA '%s' no implementado todavía; la capa IA queda inactiva.",
+        s.ai_provider,
+    )
+    return None

--- a/app/services/ai/provider.py
+++ b/app/services/ai/provider.py
@@ -21,6 +21,7 @@ class AIProvider(Protocol):
     """
 
     name: str
+    model: str
 
     def explain(self, finding: NormalizedFinding) -> AIExplanation | None:
         ...

--- a/app/services/ai/stub_provider.py
+++ b/app/services/ai/stub_provider.py
@@ -47,6 +47,7 @@ class StubProvider:
     """Proveedor determinista para tests, CI y demo offline (ADR-003)."""
 
     name = "stub"
+    model = STUB_MODEL
 
     def explain(self, finding: NormalizedFinding) -> AIExplanation:
         text = _CATEGORY_TEXT.get(finding.mvp_category, _DEFAULT_TEXT)

--- a/tests/test_ai_cache.py
+++ b/tests/test_ai_cache.py
@@ -1,0 +1,104 @@
+from app.models.ai_explanation import AIExplanation
+from app.models.finding import NormalizedFinding
+from app.services.ai.cache import (
+    ExplanationCache,
+    explain_cached,
+    explanation_cache_key,
+)
+from app.services.ai.stub_provider import StubProvider
+
+
+def _finding(category: str = "command_injection", rule: str = "B602") -> NormalizedFinding:
+    return NormalizedFinding(
+        source_tool="bandit",
+        source_rule_id=rule,
+        file_path="app.py",
+        line_start=1,
+        raw_message="msg",
+        severity="low",
+        mvp_category=category,
+        candidate_for_remediation=True,
+        remediation_mode="autofix_candidate",
+        cwe_id=78,
+    )
+
+
+class _CountingProvider:
+    name = "counting"
+    model = "counting-model"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def explain(self, finding: NormalizedFinding) -> AIExplanation:
+        self.calls += 1
+        return AIExplanation(
+            summary="s",
+            risk="r",
+            suggestion="x",
+            provider=self.name,
+            model=self.model,
+            prompt_version="v1",
+        )
+
+
+def test_cache_key_ignores_file_and_line() -> None:
+    a = _finding()
+    b = _finding()
+    b.file_path = "other.py"
+    b.line_start = 999
+    assert explanation_cache_key("stub", "m", a) == explanation_cache_key("stub", "m", b)
+
+
+def test_cache_key_differs_by_category() -> None:
+    k1 = explanation_cache_key("stub", "m", _finding("command_injection"))
+    k2 = explanation_cache_key("stub", "m", _finding("yaml_load"))
+    assert k1 != k2
+
+
+def test_explain_cached_hit_avoids_second_call() -> None:
+    provider = _CountingProvider()
+    cache = ExplanationCache()
+    finding = _finding()
+
+    first = explain_cached(provider, finding, cache)
+    second = explain_cached(provider, finding, cache)
+
+    assert provider.calls == 1
+    assert first is not None and first.cached is False
+    assert second is not None and second.cached is True
+    assert len(cache) == 1
+
+
+def test_explain_cached_stores_per_key() -> None:
+    provider = _CountingProvider()
+    cache = ExplanationCache()
+
+    explain_cached(provider, _finding("command_injection"), cache)
+    explain_cached(provider, _finding("yaml_load"), cache)
+
+    assert provider.calls == 2
+    assert len(cache) == 2
+
+
+def test_explain_cached_does_not_store_none() -> None:
+    class _NoneProvider:
+        name = "none"
+        model = "none"
+
+        def explain(self, finding: NormalizedFinding) -> None:
+            return None
+
+    cache = ExplanationCache()
+    result = explain_cached(_NoneProvider(), _finding(), cache)
+
+    assert result is None
+    assert len(cache) == 0
+
+
+def test_explain_cached_with_stub_provider() -> None:
+    cache = ExplanationCache()
+    result = explain_cached(StubProvider(), _finding(), cache)
+
+    assert result is not None
+    assert result.provider == "stub"

--- a/tests/test_ai_factory.py
+++ b/tests/test_ai_factory.py
@@ -1,0 +1,50 @@
+import pytest
+
+from app.config import Settings, get_settings
+from app.services.ai.factory import get_ai_provider
+from app.services.ai.stub_provider import StubProvider
+
+
+def _settings_with(monkeypatch: pytest.MonkeyPatch, **env: str) -> Settings:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+    return Settings()
+
+
+def test_factory_returns_none_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings_with(
+        monkeypatch,
+        TFG_AI_EXPLANATIONS_ENABLED="0",
+        TFG_AI_PROVIDER="stub",
+    )
+    try:
+        assert get_ai_provider(settings) is None
+    finally:
+        get_settings.cache_clear()
+
+
+def test_factory_returns_stub_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _settings_with(
+        monkeypatch,
+        TFG_AI_EXPLANATIONS_ENABLED="1",
+        TFG_AI_PROVIDER="stub",
+    )
+    try:
+        assert isinstance(get_ai_provider(settings), StubProvider)
+    finally:
+        get_settings.cache_clear()
+
+
+def test_factory_returns_none_for_unimplemented_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings_with(
+        monkeypatch,
+        TFG_AI_EXPLANATIONS_ENABLED="1",
+        TFG_AI_PROVIDER="ollama",
+    )
+    try:
+        assert get_ai_provider(settings) is None
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
- ExplanationCache por (provider,model,categoría,cwe,regla) + explain_cached
- get_ai_provider() respeta TFG_AI_EXPLANATIONS_ENABLED y TFG_AI_PROVIDER (degradable)
- Tests de caché y factoría; suite offline en verde (187 tests)