### PR TITLE
feat(ai): IA-3 integrar ai_explanation en presentable (schema 1.1)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from starlette.templating import Jinja2Templates
 
 from app.config import get_settings
+from app.services.ai.factory import get_ai_provider
 from app.services.analysis_service import analyze_fixtures_reports
 from app.services.pipeline_orchestrator import run_mvp_autofix_verification_roundtrip
 from app.services.presentable_scan import (
@@ -143,6 +144,7 @@ def _build_dashboard_scan(
     scan = presentable_from_internal_analysis(
         internal_scan,
         group_equivalent=group_equivalent,
+        ai_provider=get_ai_provider(),
     )
     return filter_presentable_scan(scan, hide_info=hide_info)
 
@@ -538,6 +540,7 @@ def analyze_fixtures_presentable(
         scan = presentable_from_internal_analysis(
             _attach_analysis_id(analyze_fixtures_reports(), analysis_id),
             group_equivalent=group_equivalent,
+            ai_provider=get_ai_provider(),
         )
         return filter_presentable_scan(scan, hide_info=hide_info)
     except FileNotFoundError as exc:
@@ -574,6 +577,7 @@ def run_fixtures_analysis_presentable(
                 analysis_id,
             ),
             group_equivalent=group_equivalent,
+            ai_provider=get_ai_provider(),
         )
         return filter_presentable_scan(scan, hide_info=hide_info)
     except (FileNotFoundError, RuntimeError) as exc:

--- a/app/services/presentable_scan.py
+++ b/app/services/presentable_scan.py
@@ -4,13 +4,30 @@ from datetime import UTC, datetime
 from typing import Any
 
 from app.models.finding import NormalizedFinding
+from app.services.ai.cache import ExplanationCache, explain_cached
+from app.services.ai.provider import AIProvider
 from app.services.findings_dedup import (
     group_findings_by_equivalence,
     max_severity,
     primary_finding,
 )
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"
+
+
+def _ai_explanation_for(
+    finding: NormalizedFinding,
+    provider: AIProvider | None,
+    cache: ExplanationCache,
+) -> dict[str, object] | None:
+    """Explicación IA del hallazgo (degradable: None si no hay proveedor o falla)."""
+    if provider is None:
+        return None
+    try:
+        explanation = explain_cached(provider, finding, cache)
+    except Exception:  # noqa: BLE001 - la IA nunca debe tumbar el escaneo
+        return None
+    return explanation.to_dict() if explanation is not None else None
 
 REMEDIATION_MODE_LABELS: dict[str, str] = {
     "autofix_candidate": "Remediación asistida posible (MVP)",
@@ -157,18 +174,24 @@ def build_presentable_scan(
     analysis_id: str | None = None,
     reports: dict[str, str] | None = None,
     group_equivalent: bool = False,
+    ai_provider: AIProvider | None = None,
 ) -> dict[str, Any]:
     """
     JSON estable para vista previa / memoria: sin raw_tool_data, mensajes acotados.
 
     Si group_equivalent=True, agrupa hallazgos con mismo fichero, línea y mvp_category
     y añade `sources` + `group_size` en cada fila.
+
+    Si ai_provider no es None, cada fila incluye `ai_explanation` (ADR-003); en otro
+    caso el campo es None. La generación es degradable y nunca tumba el escaneo.
     """
     from collections import Counter
 
     def _safe_label(value: Any, default: str) -> str:
         text = str(value).strip() if value is not None else ""
         return text or default
+
+    ai_cache = ExplanationCache()
 
     if group_equivalent:
         groups = group_findings_by_equivalence(findings)
@@ -177,15 +200,22 @@ def build_presentable_scan(
         by_mode = Counter(
             _safe_label(primary_finding(g).remediation_mode, "detection_only") for g in groups
         )
-        rows = [_group_to_presentable_row(i + 1, g) for i, g in enumerate(groups)]
+        rows = []
+        for i, g in enumerate(groups):
+            row = _group_to_presentable_row(i + 1, g)
+            row["ai_explanation"] = _ai_explanation_for(
+                primary_finding(g), ai_provider, ai_cache
+            )
+            rows.append(row)
     else:
         by_sev = Counter(_safe_label(f.severity, "unknown") for f in findings)
         by_cat = Counter(_safe_label(f.mvp_category, "unknown") for f in findings)
         by_mode = Counter(_safe_label(f.remediation_mode, "detection_only") for f in findings)
-        rows = [
-            _finding_to_presentable_row(i + 1, f)
-            for i, f in enumerate(findings)
-        ]
+        rows = []
+        for i, f in enumerate(findings):
+            row = _finding_to_presentable_row(i + 1, f)
+            row["ai_explanation"] = _ai_explanation_for(f, ai_provider, ai_cache)
+            rows.append(row)
 
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
@@ -225,6 +255,7 @@ def presentable_from_internal_analysis(
     internal: dict[str, Any],
     *,
     group_equivalent: bool = False,
+    ai_provider: AIProvider | None = None,
 ) -> dict[str, Any]:
     """
     Convierte la respuesta interna de analyze_fixtures_reports / analyze_fixtures_runtime
@@ -259,6 +290,7 @@ def presentable_from_internal_analysis(
         analysis_id=internal.get("analysis_id"),
         reports=reports,
         group_equivalent=group_equivalent,
+        ai_provider=ai_provider,
     )
     if invalid_findings:
         out_meta = dict(out.get("meta") or {})

--- a/tests/test_ai_presentable.py
+++ b/tests/test_ai_presentable.py
@@ -1,0 +1,85 @@
+from app.models.finding import NormalizedFinding
+from app.services.ai.stub_provider import StubProvider
+from app.services.presentable_scan import build_presentable_scan
+
+
+def _findings() -> list[NormalizedFinding]:
+    return [
+        NormalizedFinding(
+            source_tool="bandit",
+            source_rule_id="B602",
+            file_path="app.py",
+            line_start=1,
+            raw_message="subprocess shell=True",
+            severity="high",
+            mvp_category="command_injection",
+            candidate_for_remediation=True,
+            remediation_mode="autofix_candidate",
+            cwe_id=78,
+        ),
+        NormalizedFinding(
+            source_tool="bandit",
+            source_rule_id="B506",
+            file_path="conf.py",
+            line_start=4,
+            raw_message="yaml.load",
+            severity="medium",
+            mvp_category="yaml_load",
+            candidate_for_remediation=True,
+            remediation_mode="autofix_candidate",
+            cwe_id=20,
+        ),
+    ]
+
+
+def test_presentable_without_provider_has_null_explanation() -> None:
+    out = build_presentable_scan(
+        _findings(),
+        analysis_target="x",
+        execution_mode="runtime",
+    )
+    assert out["schema_version"] == "1.1"
+    for row in out["findings"]:
+        assert row["ai_explanation"] is None
+
+
+def test_presentable_with_stub_provider_adds_explanation() -> None:
+    out = build_presentable_scan(
+        _findings(),
+        analysis_target="x",
+        execution_mode="runtime",
+        ai_provider=StubProvider(),
+    )
+    rows = out["findings"]
+    assert all(row["ai_explanation"] is not None for row in rows)
+    first = rows[0]["ai_explanation"]
+    assert first["provider"] == "stub"
+    assert "comando" in first["summary"].lower()
+    assert first["suggestion"]
+
+
+def test_presentable_grouped_with_stub_provider() -> None:
+    findings = _findings() + _findings()  # duplica → grupos equivalentes
+    out = build_presentable_scan(
+        findings,
+        analysis_target="x",
+        execution_mode="runtime",
+        group_equivalent=True,
+        ai_provider=StubProvider(),
+    )
+    for row in out["findings"]:
+        assert row["ai_explanation"] is not None
+        assert row["ai_explanation"]["provider"] == "stub"
+
+
+def test_presentable_explanation_uses_cache_marker() -> None:
+    # Dos hallazgos de la misma categoría/regla/cwe: el segundo viene de caché.
+    findings = [_findings()[0], _findings()[0]]
+    out = build_presentable_scan(
+        findings,
+        analysis_target="x",
+        execution_mode="runtime",
+        ai_provider=StubProvider(),
+    )
+    cached_flags = [row["ai_explanation"]["cached"] for row in out["findings"]]
+    assert cached_flags == [False, True]

--- a/tests/test_presentable_scan.py
+++ b/tests/test_presentable_scan.py
@@ -36,7 +36,7 @@ def test_build_presentable_scan_shape() -> None:
         reports={"bandit": "r1.json", "semgrep": "r2.json"},
     )
 
-    assert out["schema_version"] == "1.0"
+    assert out["schema_version"] == "1.1"
     assert out["meta"]["execution_mode"] == "static_reports"
     assert "generated_at" in out["meta"]
     assert out["meta"]["reports"]["bandit"] == "r1.json"
@@ -239,6 +239,6 @@ def test_presentable_fixtures_endpoint_if_reports_exist() -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert body["schema_version"] == "1.0"
+    assert body["schema_version"] == "1.1"
     assert body["summary"]["total_findings"] > 0
     assert isinstance(body["findings"], list)

--- a/tests/test_run_fixtures_endpoint.py
+++ b/tests/test_run_fixtures_endpoint.py
@@ -99,7 +99,7 @@ def test_run_fixtures_presentable_endpoint_returns_filtered_payload(monkeypatch)
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["schema_version"] == "1.0"
+    assert payload["schema_version"] == "1.1"
     assert payload["meta"]["execution_mode"] == "runtime"
     assert isinstance(payload["meta"]["analysis_id"], str)
     assert payload["meta"]["presentable_filter"] == "hide_info"


### PR DESCRIPTION
- build_presentable_scan/presentable_from_internal aceptan ai_provider y enriquecen filas
- Campo ai_explanation por hallazgo y grupo; null si IA desactivada; degradable
- Cableado get_ai_provider() en dashboard y endpoints presentables
- Tests de integración IA y actualización de schema 1.0->1.1 (191 tests)