### PR TITLE
feat(ai): IA-4 render de la explicación IA en el dashboard con discla…

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -513,6 +513,60 @@
       z-index: 1;
       max-width: 70ch;
     }
+    .ai-explanation {
+      margin: 0.4rem 0 0.8rem;
+      padding: 0.85rem 1rem;
+      border-radius: var(--radius-lg);
+      border: 1px solid rgba(124, 196, 255, 0.35);
+      background: rgba(124, 196, 255, 0.07);
+      position: relative;
+      z-index: 1;
+    }
+    .ai-explanation-head {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.5rem;
+    }
+    .ai-tag {
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #bfe3ff;
+      padding: 0.18rem 0.5rem;
+      border-radius: 999px;
+      border: 1px solid rgba(124, 196, 255, 0.45);
+      background: rgba(124, 196, 255, 0.12);
+    }
+    .ai-meta {
+      font-size: 0.74rem;
+      color: var(--muted);
+    }
+    .ai-explanation dl {
+      display: grid;
+      gap: 0.4rem;
+      margin: 0;
+    }
+    .ai-explanation dt {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      color: var(--muted);
+    }
+    .ai-explanation dd {
+      margin: 0 0 0.3rem;
+      font-size: 0.92rem;
+      color: #e9f4ff;
+      max-width: 72ch;
+    }
+    .ai-disclaimer {
+      margin-top: 0.5rem;
+      font-size: 0.74rem;
+      color: var(--muted);
+      font-style: italic;
+    }
     .empty {
       padding: 2rem 1rem;
       border-radius: var(--radius-lg);
@@ -872,6 +926,30 @@
                 {% endif %}
               </div>
             </div>
+
+            {% if row.ai_explanation %}
+            <div class="ai-explanation">
+              <div class="ai-explanation-head">
+                <span class="ai-tag">Explicación IA</span>
+                <span class="ai-meta">
+                  {{ row.ai_explanation.provider }}/{{ row.ai_explanation.model }}
+                  {% if row.ai_explanation.cached %}· caché{% endif %}
+                </span>
+              </div>
+              <dl>
+                <dt>Resumen</dt>
+                <dd>{{ row.ai_explanation.summary }}</dd>
+                <dt>Riesgo</dt>
+                <dd>{{ row.ai_explanation.risk }}</dd>
+                <dt>Sugerencia</dt>
+                <dd>{{ row.ai_explanation.suggestion }}</dd>
+              </dl>
+              <p class="ai-disclaimer">
+                Explicación generada por IA; puede contener errores. La verificación la
+                aportan Bandit/Semgrep y los remediadores deterministas.
+              </p>
+            </div>
+            {% endif %}
 
             {% if row.sources is defined and row.sources|length > 1 %}
             <div class="source-list">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -264,3 +264,41 @@ def test_dashboard_analyze_git_clone_disabled(monkeypatch) -> None:
         assert "git clone está desactivado" in response.text
     finally:
         get_settings.cache_clear()
+
+
+def test_dashboard_renders_ai_explanation_when_enabled(monkeypatch) -> None:
+    from app.config import get_settings
+
+    bandit = Path("reports/bandit/fixtures-mvp-bandit.json")
+    semgrep = Path("reports/semgrep/fixtures-mvp-semgrep.json")
+    if not bandit.exists() or not semgrep.exists():
+        return
+
+    monkeypatch.setenv("TFG_AI_EXPLANATIONS_ENABLED", "1")
+    monkeypatch.setenv("TFG_AI_PROVIDER", "stub")
+    get_settings.cache_clear()
+    try:
+        response = client.get("/dashboard")
+        assert response.status_code == 200
+        assert "Explicación IA" in response.text
+        assert "Explicación generada por IA" in response.text
+    finally:
+        get_settings.cache_clear()
+
+
+def test_dashboard_omits_ai_explanation_when_disabled(monkeypatch) -> None:
+    from app.config import get_settings
+
+    bandit = Path("reports/bandit/fixtures-mvp-bandit.json")
+    semgrep = Path("reports/semgrep/fixtures-mvp-semgrep.json")
+    if not bandit.exists() or not semgrep.exists():
+        return
+
+    monkeypatch.setenv("TFG_AI_EXPLANATIONS_ENABLED", "0")
+    get_settings.cache_clear()
+    try:
+        response = client.get("/dashboard")
+        assert response.status_code == 200
+        assert "Explicación IA" not in response.text
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
…imer

- Bloque por hallazgo (resumen/riesgo/sugerencia) + metadatos y badge caché
- Disclaimer de contenido generado por IA; verificación por Bandit/Semgrep
- Se omite si no hay ai_explanation; tests de render on/off (193 tests)