### PR TITLE
feat(config): carga automática de .env al arrancar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Configuración de ejemplo del backend (análisis real, sin IA).
 # Todas las variables son opcionales: si no se definen, se usan los valores por
-# defecto seguros de app/config.py. Copia este fichero a .env solo si necesitas
-# ajustar el comportamiento; el .env no debe subirse al repositorio.
+# defecto seguros de app/config.py. Copia este fichero a `.env` en la raíz del
+# repo; el backend lo carga al arrancar (sin sobrescribir variables ya exportadas).
+# El `.env` no debe subirse al repositorio.
 
 # --- Límites de subida ZIP ---
 # Tamaño máximo del ZIP recibido (bytes). Por defecto ~20 MB.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ export PATH="$PWD/.venv/bin:$PATH"
 uvicorn app.main:app --reload
 ```
 
+Opcional: copia `.env.example` a `.env` en la raíz del repo (IA, límites ZIP, etc.). El backend **carga `.env` al arrancar**; las variables ya exportadas en la shell o en systemd tienen prioridad.
+
 - Salud: `GET http://127.0.0.1:8000/health`
 - Inicio: `GET http://127.0.0.1:8000/` (redirección 302 a `/dashboard`)
 - Dashboard: `GET http://127.0.0.1:8000/dashboard`

--- a/app/config.py
+++ b/app/config.py
@@ -6,6 +6,28 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_project_dotenv(*, repo_root: Path | None = None) -> bool:
+    """
+    Carga `.env` del repositorio si existe.
+
+    No sobrescribe variables ya definidas en el entorno del proceso (p. ej. systemd
+    o `export` previo en la shell), de modo que el despliegue explícito sigue
+    teniendo prioridad.
+    """
+    env_path = (repo_root or _REPO_ROOT) / ".env"
+    if not env_path.is_file():
+        return False
+    load_dotenv(env_path, override=False)
+    return True
+
+
+load_project_dotenv()
+
 # Bandit `-x` acepta lista separada por comas (globs). Semgrep usa la misma
 # lista para generar varios `--exclude` (ver `build_semgrep_command`).
 _DEFAULT_ANALYSIS_EXCLUDE_DIRS = (

--- a/docs/04_delivery/manual-usuario-web.md
+++ b/docs/04_delivery/manual-usuario-web.md
@@ -30,7 +30,7 @@ Por defecto la IA está desactivada. Para ver el toggle en el formulario o el bo
 TFG_AI_EXPLANATIONS_ENABLED=1 TFG_AI_PROVIDER=stub uvicorn app.main:app --host 127.0.0.1 --port 8000
 ```
 
-En producción (VPS) se configura en `.env`. Con `stub` no hace falta Ollama; con `ollama` se usa un modelo local.
+En producción (VPS) se configura en `.env` en la raíz del proyecto; el backend lo carga al arrancar. Con `stub` no hace falta Ollama; con `ollama` se usa un modelo local.
 
 ## 3. Flujo recomendado para la defensa
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "uvicorn[standard]>=0.30",
     "jinja2>=3.1",
     "python-multipart>=0.0.9",
+    "python-dotenv>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import pytest
 
 from app.config import Settings, get_settings
@@ -96,3 +99,33 @@ def test_settings_ai_provider_normalized(monkeypatch: pytest.MonkeyPatch) -> Non
         assert Settings().ai_provider == "stub"
     finally:
         get_settings.cache_clear()
+
+
+def test_load_project_dotenv_reads_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.config import load_project_dotenv
+
+    monkeypatch.delenv("TFG_AI_EXPLANATIONS_ENABLED", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("TFG_AI_EXPLANATIONS_ENABLED=1\n", encoding="utf-8")
+
+    assert load_project_dotenv(repo_root=tmp_path) is True
+    assert os.environ.get("TFG_AI_EXPLANATIONS_ENABLED") == "1"
+
+
+def test_load_project_dotenv_does_not_override_existing_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.config import load_project_dotenv
+
+    monkeypatch.setenv("TFG_AI_EXPLANATIONS_ENABLED", "0")
+    env_file = tmp_path / ".env"
+    env_file.write_text("TFG_AI_EXPLANATIONS_ENABLED=1\n", encoding="utf-8")
+
+    load_project_dotenv(repo_root=tmp_path)
+    assert os.environ.get("TFG_AI_EXPLANATIONS_ENABLED") == "0"
+
+
+def test_load_project_dotenv_missing_file(tmp_path: Path) -> None:
+    from app.config import load_project_dotenv
+
+    assert load_project_dotenv(repo_root=tmp_path) is False


### PR DESCRIPTION
Lee .env en la raíz del repo con python-dotenv sin sobrescribir variables ya exportadas; corrige IA desactivada cuando solo existía en el fichero.